### PR TITLE
Fix leaveGame attempt to end empty game with wrong uuid

### DIFF
--- a/src/main/java/com/civservers/simple_tag/simpletag/SimpleTag.java
+++ b/src/main/java/com/civservers/simple_tag/simpletag/SimpleTag.java
@@ -124,7 +124,7 @@ public final class SimpleTag extends JavaPlugin implements Listener {
 			
 			
 			if (playerList.isEmpty()) {
-				config.set("games." + uuid, null);
+				config.set("games." + gameUuid, null);
 				saveConfig();
 				sendPlayer(player,ChatColor.RED + msgs.get("stop").toString());
 			} else {


### PR DESCRIPTION
It appears there is a typo in leaveGame using the wrong uuid to stop an empty game.

Since the game uuid is the game starter's player uuid, it would appear as a problem only if the game starter left early, meaning some remaining player is trying to be last to leave.
